### PR TITLE
documentation: added instruction to compute cross product at end of 10

### DIFF
--- a/10 - Basic linear algebra.ipynb
+++ b/10 - Basic linear algebra.ipynb
@@ -25,9 +25,9 @@
      "data": {
       "text/plain": [
        "3×3 Matrix{Int64}:\n",
-       " 2  4  4\n",
-       " 3  3  2\n",
-       " 2  2  4"
+       " 3  1  3\n",
+       " 1  1  2\n",
+       " 3  2  2"
       ]
      },
      "execution_count": 1,
@@ -88,9 +88,9 @@
      "data": {
       "text/plain": [
        "3-element Vector{Float64}:\n",
-       " 10.0\n",
-       "  8.0\n",
-       "  8.0"
+       " 7.0\n",
+       " 4.0\n",
+       " 7.0"
       ]
      },
      "execution_count": 3,
@@ -119,9 +119,9 @@
      "data": {
       "text/plain": [
        "3×3 adjoint(::Matrix{Int64}) with eltype Int64:\n",
-       " 2  3  2\n",
-       " 4  3  2\n",
-       " 4  2  4"
+       " 3  1  3\n",
+       " 1  1  2\n",
+       " 3  2  2"
       ]
      },
      "execution_count": 4,
@@ -149,9 +149,9 @@
      "data": {
       "text/plain": [
        "3×3 transpose(::Matrix{Int64}) with eltype Int64:\n",
-       " 2  3  2\n",
-       " 4  3  2\n",
-       " 4  2  4"
+       " 3  1  3\n",
+       " 1  1  2\n",
+       " 3  2  2"
       ]
      },
      "execution_count": 5,
@@ -180,9 +180,9 @@
      "data": {
       "text/plain": [
        "3×3 Matrix{Int64}:\n",
-       " 17  21  22\n",
-       " 21  29  30\n",
-       " 22  30  36"
+       " 19  10  17\n",
+       " 10   6   9\n",
+       " 17   9  17"
       ]
      },
      "execution_count": 6,
@@ -241,9 +241,9 @@
      "data": {
       "text/plain": [
        "3×2 Matrix{Float64}:\n",
-       " 0.857677  0.844745\n",
-       " 0.761544  0.00556007\n",
-       " 0.858307  0.945107"
+       " 0.01259    0.562346\n",
+       " 0.571931   0.208287\n",
+       " 0.0761351  0.507003"
       ]
      },
      "execution_count": 8,
@@ -264,8 +264,8 @@
      "data": {
       "text/plain": [
        "2-element Vector{Float64}:\n",
-       " 10.671282490997186\n",
-       " -0.23673103091602224"
+       "  2.3722998636787898\n",
+       " 12.85556853172185"
       ]
      },
      "execution_count": 9,
@@ -293,9 +293,9 @@
      "data": {
       "text/plain": [
        "3×2 Matrix{Float64}:\n",
-       " 0.419272   0.419272\n",
-       " 0.0771968  0.0771968\n",
-       " 0.789389   0.789389"
+       " 0.682093  0.682093\n",
+       " 0.745287  0.745287\n",
+       " 0.698837  0.698837"
       ]
      },
      "execution_count": 10,
@@ -317,8 +317,8 @@
      "data": {
       "text/plain": [
        "2-element Vector{Float64}:\n",
-       " 6.911188009717366\n",
-       " 6.911188009717363"
+       " 4.190527048390038\n",
+       " 4.190527048390039"
       ]
      },
      "execution_count": 11,
@@ -346,8 +346,8 @@
      "data": {
       "text/plain": [
        "2×3 Matrix{Float64}:\n",
-       " 0.456691  0.726932  0.871714\n",
-       " 0.946701  0.523393  0.776277"
+       " 0.692218  0.193236   0.153774\n",
+       " 0.127852  0.0359394  0.063034"
       ]
      },
      "execution_count": 12,
@@ -369,9 +369,9 @@
      "data": {
       "text/plain": [
        "3-element Vector{Float64}:\n",
-       " -0.9440933746386968\n",
-       "  0.9494588198150655\n",
-       "  0.7679512373794606"
+       " -4.139674407706176\n",
+       " -0.9797338415813472\n",
+       " 23.563074056363842"
       ]
      },
      "execution_count": 13,
@@ -405,9 +405,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3-element Vector{Int64}:\n",
+       " 1\n",
+       " 2\n",
+       " 3"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "v = [1,2,3]"
    ]
@@ -421,7 +435,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {
     "deletable": false,
     "editable": false,
@@ -458,7 +472,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -468,8 +482,23 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 10.3 \n",
+    "Use [LinearAlgebra.cross](https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/#LinearAlgebra.cross) to compute the cross product of a vector v with itself and assign it to variable `cross_v`"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
    "metadata": {
     "deletable": false,
     "editable": false,
@@ -492,16 +521,16 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.6.0",
+   "display_name": "Julia 1.7.1",
    "language": "julia",
-   "name": "julia-1.6"
+   "name": "julia-1.7"
   },
   "language": "Julia",
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.6.3"
+   "version": "1.7.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Dear Logan et al, 

The end of the lesson 10 notebook has an assert for "cross_v" without any instructions on what's expected for that.  I simply added a little markdown text and gave it its own exercise number. 

When I re-ran the notebook, the random numbers were different than the previous commit. 